### PR TITLE
Use SUITE library scope

### DIFF
--- a/EggplantLibrary/__init__.py
+++ b/EggplantLibrary/__init__.py
@@ -23,7 +23,7 @@ class EggplantLibrary(EggplantLibDynamicCore):
     See the [https://github.com/amochin/robotframework-eggplant|Eggplant Library homepage] for more information.
     """
     ROBOT_LIBRARY_VERSION = VERSION
-    ROBOT_LIBRARY_SCOPE = 'TEST SUITE'
+    ROBOT_LIBRARY_SCOPE = 'SUITE'
 
     # ---------- static keywords ------------------------------
     @keyword

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3",
         "Operating System :: Microsoft :: Windows",
         "License :: OSI Approved :: Apache Software License",
+        "Framework :: Robot Framework :: Library",
     ],
     install_requires=[
         'robotframework',


### PR DESCRIPTION
a minor thing.

`TEST SUITE` was the name of the library scope prior RF 3.2 (https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#library-scope) 

From 3.2 onwards it is `SUITE`.

I also added Robot Framework to python package classifiers.